### PR TITLE
Added a link to the github in the header

### DIFF
--- a/_data/i18n/general.yml
+++ b/_data/i18n/general.yml
@@ -24,6 +24,10 @@ head:
   youarehere:
     en: You are here
     fr: Vous êtes ici
+  sourceCode:
+    en: View source code and data
+    fr: Voir le code source et les données
+
 
 nav:
   home:

--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -14,5 +14,8 @@
         <li><a href="{{ site.data.i18n.general.nav.partnership.link[page.lang] }}">{{ site.data.i18n.general.nav.partnership[page.lang] }}</a></li>
       {%- endif -%}
     </ol>
+    <ol class="git-link">
+      <li><a href="https://github.com/canada-ca/ore-ero">{{ site.data.i18n.general.head.sourceCode[page.lang] }}</a></li>
+    </ol>
   </div>
 </nav>


### PR DESCRIPTION
Someone proposed to add a direct link to the source code accessible from anywhere on the website (issue #796). I added a link in the header just under home.